### PR TITLE
feat: create local.Dockerfile of dollar-auth

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.github
+.gradle
+build
+node_modules
+*.log
+docker

--- a/docker/local.Dockerfile
+++ b/docker/local.Dockerfile
@@ -1,0 +1,25 @@
+# Build Stage
+FROM gradle:8.5-jdk17 AS builder
+
+WORKDIR /build
+
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle settings.gradle ./
+
+RUN chmod +x gradlew
+RUN ./gradlew dependencies --no-daemon
+
+COPY src src
+RUN ./gradlew bootJar --no-daemon
+
+# Run Stage
+FROM eclipse-temurin:17-jre-jammy
+
+WORKDIR /app
+
+COPY --from=builder /build/build/libs/*.jar app.jar
+
+EXPOSE 29080
+
+ENTRYPOINT ["java", "-jar", "app.jar", "--spring.profiles.active=local"]


### PR DESCRIPTION
## ✅ 구현된 기능
- dollar-auth에 대한 local.Dockerfile 생성
- build stage /run stage 나눠서 구성 (각각 jdk/jre image 사용)

(정상 실행 확인)
<img width="1813" height="690" alt="auth 서버 정상작동" src="https://github.com/user-attachments/assets/ed87af52-8314-40a8-b817-cde347a127a5" />


---

## 🚨 리뷰 포인트
<!-- 특별히 봐줬으면 하는 부분 -->
- 빌드 시 이미지 크기를 줄이기 위해 .dockerignore 추가 생성